### PR TITLE
Fix imports for PaddleOCR singleton usage

### DIFF
--- a/OmniParser/util/utils.py
+++ b/OmniParser/util/utils.py
@@ -33,7 +33,7 @@ import re
 from torchvision.transforms import ToPILImage
 import supervision as sv
 import torchvision.transforms as T
-from util.box_annotator import BoxAnnotator
+from .box_annotator import BoxAnnotator
 
 # ──────────────────────────────
 # Singleton for PaddleOCR

--- a/worker.py
+++ b/worker.py
@@ -38,11 +38,12 @@ DEBUG_IMG = args.img
 # ───────────────────────────
 # Model (inline omni_parse_json) – returns TEXT items only
 # ───────────────────────────
-from util.utils import (
+from OmniParser.util.utils import (
     check_ocr_box,
     get_yolo_model,
     get_caption_model_processor,
     get_som_labeled_img,
+    _get_paddle_ocr,            # 單例取得 PaddleOCR
 )
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -57,6 +58,9 @@ caption_model_processor = get_caption_model_processor(
     model_name="florence2",
     model_name_or_path="weights/icon_caption_florence",
 )
+
+# 建立全域 PaddleOCR 單例，避免重複 build predictor
+GLOBAL_PADDLE_OCR = _get_paddle_ocr(use_gpu=(DEVICE.type == "cuda"))
 
 @torch.inference_mode()
 def omni_parse_json(
@@ -73,6 +77,7 @@ def omni_parse_json(
         output_bb_format="xyxy",
         easyocr_args={"paragraph": False, "text_threshold": 0.9},
         use_paddleocr=use_paddleocr,
+        paddle_ocr=GLOBAL_PADDLE_OCR,
     )
     _, _, parsed = get_som_labeled_img(
         img,

--- a/worker_batch.py
+++ b/worker_batch.py
@@ -46,7 +46,7 @@ BATCH_SIZE = args.batch_size
 # ───────────────────────────
 # Model utils
 # ───────────────────────────
-from util.utils import (
+from OmniParser.util.utils import (
     check_ocr_box,
     get_caption_model_processor,
     get_som_labeled_img,


### PR DESCRIPTION
## Summary
- import utils from `OmniParser.util` so modules work regardless of CWD
- use relative import for `BoxAnnotator` inside utils
- keep PaddleOCR singleton accessible for both workers

## Testing
- `python3 -m py_compile worker.py worker_batch.py`
- `python worker_batch.py --help` *(fails: ModuleNotFoundError: No module named 'paddle')*
