### PR TITLE
統一 PaddleOCR predictor 使用

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -62,9 +62,6 @@ caption_model_processor = get_caption_model_processor(
 # 建立全域 PaddleOCR 單例，避免重複 build predictor
 GLOBAL_PADDLE_OCR = _get_paddle_ocr(use_gpu=(DEVICE.type == "cuda"))
 
-# 建立全域 PaddleOCR 單例，避免重複 build predictor
-GLOBAL_PADDLE_OCR = _get_paddle_ocr(use_gpu=(DEVICE.type == "cuda"))
-
 @torch.inference_mode()
 def omni_parse_json(
     image_path: str | Path,

--- a/worker_batch.py
+++ b/worker_batch.py
@@ -85,6 +85,7 @@ def omni_parse_json_single(
         output_bb_format="xyxy",
         easyocr_args={"paragraph": False, "text_threshold": 0.9},
         use_paddleocr=use_paddleocr,
+        paddle_ocr=GLOBAL_PADDLE_OCR,
     )
     _, _, parsed = get_som_labeled_img(
         img,
@@ -119,6 +120,7 @@ def omni_parse_json_batch(
             output_bb_format="xyxy",
             easyocr_args={"paragraph": False, "text_threshold": 0.9},
             use_paddleocr=use_paddleocr,
+            paddle_ocr=GLOBAL_PADDLE_OCR,
         )
         _, _, parsed = get_som_labeled_img(
             img,


### PR DESCRIPTION
## Summary
- 清除 worker.py 中重複的 PaddleOCR 建立
- 將 `worker_batch.py` 與 `gradio_demo.py` 的 `check_ocr_box` 改為傳入全域 `GLOBAL_PADDLE_OCR`
- 新增 `GLOBAL_PADDLE_OCR` 於 `gradio_demo.py` 以避免重複建構 predictor

## Testing
- `python -m py_compile worker.py worker_batch.py OmniParser/gradio_demo.py`