### PR TITLE
改善 PaddleOCR 記憶體釋放

### DIFF
--- a/util/memory.py
+++ b/util/memory.py
@@ -1,0 +1,19 @@
+"""GPU memory utilities for PaddleOCR"""
+
+
+def release_ocr_gpu_cache(ocr_reader):
+    """針對 PaddleOCR 三個 predictor 逐一釋放 GPU 暫存"""
+    for name in ("text_detector", "text_classifier", "text_recognizer"):
+        comp = getattr(ocr_reader, name, None)
+        if comp is None or not hasattr(comp, "predictor"):
+            continue
+        pred = comp.predictor
+        try:
+            pred.clear_intermediate_tensor()
+        except Exception:
+            pass
+        try:
+            pred.try_shrink_memory()
+        except Exception:
+            pass
+

--- a/worker_batch.py
+++ b/worker_batch.py
@@ -20,6 +20,9 @@ import time
 from pathlib import Path
 from typing import List, Tuple
 
+import os
+os.environ["FLAGS_allocator_strategy"] = "auto_growth"  # GPU 記憶體按需配置
+
 import paddle
 import contextlib
 import io
@@ -54,6 +57,7 @@ from OmniParser.util.utils import (
     get_yolo_model,
     _get_paddle_ocr,                # <──── util 中的單例 helper
 )
+from util.memory import release_ocr_gpu_cache
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -136,6 +140,7 @@ def omni_parse_json_batch(
         outputs.append([i.get("content", "") for i in parsed if i.get("content")])
 
     # 主動清理未再使用的張量並釋放 GPU 快取
+    release_ocr_gpu_cache(GLOBAL_PADDLE_OCR)
     del imgs
     gc.collect()
     if torch.cuda.is_available():


### PR DESCRIPTION
## Summary
- 啟用 `auto_growth` 以避免一次佔滿 GPU
- 新增 `util.memory` 提供 `release_ocr_gpu_cache`
- 於批次推論後回收 PaddleOCR 顯存

## Testing
- `pytest -q`