### PR TITLE
減少模型載入與顯存佔用

### DIFF
--- a/OmniParser/eval/ss_pro_gpt4o_omniv2.py
+++ b/OmniParser/eval/ss_pro_gpt4o_omniv2.py
@@ -25,10 +25,7 @@ from PIL import Image
 device = 'cuda' if torch.cuda.is_available() else 'cpu'
 SOM_MODEL_PATH='...'
 CAPTION_MODEL_PATH='...'
-som_model = get_yolo_model(SOM_MODEL_PATH)
-
-som_model.to(device)
-print('model to {}'.format(device))
+som_model = get_yolo_model(SOM_MODEL_PATH, device=device)
 
 # two choices for caption model: fine-tuned blip2 or florence2
 import importlib

--- a/OmniParser/gradio_demo.py
+++ b/OmniParser/gradio_demo.py
@@ -18,7 +18,7 @@ from util.utils import (
 import torch
 from PIL import Image
 
-yolo_model = get_yolo_model(model_path='weights/icon_detect/model.pt')
+yolo_model = get_yolo_model('weights/icon_detect/model.pt', device=torch.device('cuda' if torch.cuda.is_available() else 'cpu'))
 caption_model_processor = get_caption_model_processor(model_name="florence2", model_name_or_path="weights/icon_caption_florence")
 # caption_model_processor = get_caption_model_processor(model_name="blip2", model_name_or_path="weights/icon_caption_blip2")
 

--- a/OmniParser/util/omniparser.py
+++ b/OmniParser/util/omniparser.py
@@ -9,7 +9,7 @@ class Omniparser(object):
         self.config = config
         device = 'cuda' if torch.cuda.is_available() else 'cpu'
 
-        self.som_model = get_yolo_model(model_path=config['som_model_path'])
+        self.som_model = get_yolo_model(config['som_model_path'], device=device)
         self.caption_model_processor = get_caption_model_processor(model_name=config['caption_model_name'], model_name_or_path=config['caption_model_path'], device=device)
         print('Omniparser initialized!!!')
 

--- a/worker.py
+++ b/worker.py
@@ -48,11 +48,7 @@ from OmniParser.util.utils import (
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-yolo_model = get_yolo_model(model_path="weights/icon_detect/model.pt")
-try:
-    yolo_model = yolo_model.to(DEVICE)  # ignore if .to not available
-except AttributeError:
-    pass
+yolo_model = get_yolo_model("weights/icon_detect/model.pt", device=DEVICE)
 
 caption_model_processor = get_caption_model_processor(
     model_name="florence2",

--- a/worker_batch.py
+++ b/worker_batch.py
@@ -60,7 +60,7 @@ from OmniParser.util.utils import (
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
-yolo_model = get_yolo_model("weights/icon_detect/model.pt").to(DEVICE)
+yolo_model = get_yolo_model("weights/icon_detect/model.pt", device=DEVICE)
 caption_model_processor = get_caption_model_processor(
     model_name="florence2",
     model_name_or_path="weights/icon_caption_florence",


### PR DESCRIPTION
## Summary
- 對 YOLO 與 Caption Model 建立全域快取
- 移除 PaddleOCR `gpu_mem` 固定配置
- 依新的快取介面調整各程式載入

## Testing
- `python -m py_compile worker.py worker_batch.py OmniParser/util/utils.py OmniParser/util/omniparser.py OmniParser/gradio_demo.py OmniParser/util/ocr_worker.py OmniParser/eval/ss_pro_gpt4o_omniv2.py`