### PR TITLE
增加GPU記憶體調用debug打印

### DIFF
--- a/OmniParser/util/ocr_worker.py
+++ b/OmniParser/util/ocr_worker.py
@@ -8,6 +8,7 @@
 import os, sys, json, gc, tempfile
 from PIL import Image
 from OmniParser.util.utils import check_ocr_box, _get_paddle_ocr
+from util.memory import debug_gpu_memory
 
 # ─ GPU 設定（想用 CPU 可以改 use_gpu=False） ───────────
 os.environ["FLAGS_allocator_strategy"] = "auto_growth"
@@ -29,6 +30,7 @@ def run(img_path):
     # 結束前盡可能清空 Pool
     import paddle
     gc.collect(); paddle.device.cuda.empty_cache()
+    debug_gpu_memory("ocr_worker run")
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:

--- a/OmniParser/util/utils.py
+++ b/OmniParser/util/utils.py
@@ -18,6 +18,7 @@ import os
 import cv2
 import numpy as np
 # %matplotlib inline
+from util.memory import debug_gpu_memory
 from matplotlib import pyplot as plt
 import easyocr
 from paddleocr import PaddleOCR
@@ -51,7 +52,8 @@ def _get_paddle_ocr(use_gpu: bool = True, rec_batch_num: int = 1024) -> "PaddleO
     """
     if PaddleOCR is None:
         raise RuntimeError("PaddleOCR package is not installed")
-    return PaddleOCR(
+    debug_gpu_memory("_get_paddle_ocr (before build)")
+    ocr = PaddleOCR(
         lang='ch',              # other lang also available
         use_angle_cls=False,
         use_gpu=use_gpu,
@@ -61,6 +63,8 @@ def _get_paddle_ocr(use_gpu: bool = True, rec_batch_num: int = 1024) -> "PaddleO
         use_dilation=True,      # improves accuracy
         det_db_score_mode='slow',  # improves accuracy
     )
+    debug_gpu_memory("_get_paddle_ocr (after build)")
+    return ocr
 
 # ──────────────────────────────
 # Main function

--- a/util/memory.py
+++ b/util/memory.py
@@ -1,8 +1,39 @@
 """GPU memory utilities for PaddleOCR"""
 
+from __future__ import annotations
+
+try:  # 避免在缺少套件時失敗
+    import torch
+except Exception:  # pragma: no cover - 避免測試環境缺套件
+    torch = None
+
+try:  # pragma: no cover - 同上
+    import paddle
+except Exception:  # pragma: no cover - 同上
+    paddle = None
+
+
+def debug_gpu_memory(func_name: str) -> None:
+    """Print current GPU memory usage for debug purpose."""
+    torch_mem = "N/A"
+    paddle_mem = "N/A"
+    try:
+        if torch and torch.cuda.is_available():
+            torch_mem = int(torch.cuda.memory_allocated() / 1024 / 1024)
+    except Exception:  # pragma: no cover - 避免任何意外錯誤
+        pass
+    try:
+        if paddle and paddle.is_compiled_with_cuda():
+            free, total = paddle.device.cuda.mem_get_info()
+            paddle_mem = int((total - free) / 1024 / 1024)
+    except Exception:  # pragma: no cover - 避免任何意外錯誤
+        pass
+    print(f"[DEBUG] {func_name}: torch_gpu={torch_mem}MB paddle_gpu={paddle_mem}MB")
+
 
 def release_ocr_gpu_cache(ocr_reader):
     """針對 PaddleOCR 三個 predictor 逐一釋放 GPU 暫存"""
+    debug_gpu_memory("release_ocr_gpu_cache (before)")
     for name in ("text_detector", "text_classifier", "text_recognizer"):
         comp = getattr(ocr_reader, name, None)
         if comp is None or not hasattr(comp, "predictor"):
@@ -10,10 +41,12 @@ def release_ocr_gpu_cache(ocr_reader):
         pred = comp.predictor
         try:
             pred.clear_intermediate_tensor()
+            debug_gpu_memory(f"release_ocr_gpu_cache clear {name}")
         except Exception:
             pass
         try:
             pred.try_shrink_memory()
+            debug_gpu_memory(f"release_ocr_gpu_cache shrink {name}")
         except Exception:
             pass
 

--- a/worker_batch.py
+++ b/worker_batch.py
@@ -27,6 +27,8 @@ import paddle
 import contextlib
 import io
 
+from util.memory import debug_gpu_memory
+
 import torch
 import gc
 import contextlib
@@ -146,6 +148,7 @@ def omni_parse_json_batch(
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
         paddle.device.cuda.empty_cache()
+        debug_gpu_memory("omni_parse_json_batch")
 
     return outputs
 
@@ -317,6 +320,7 @@ def worker_loop():
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
                 paddle.device.cuda.empty_cache()
+                debug_gpu_memory("worker_loop finally")
 
 # ───────────────────────────
 # Boot


### PR DESCRIPTION
## Summary
- 新增 `debug_gpu_memory` 函式，輸出目前 GPU 佔用量
- `release_ocr_gpu_cache`、`_get_paddle_ocr`、`ocr_worker` 與 `worker_batch` 中加入呼叫
- 每次釋放或初始化 GPU 記憶體後皆輸出函式名稱與占用資訊

## Testing
- `pytest -q`