### PR TITLE
修正 box_annotator 模組路徑

### DIFF
--- a/OmniParser/util/utils.py
+++ b/OmniParser/util/utils.py
@@ -43,7 +43,10 @@ import re
 from torchvision.transforms import ToPILImage
 import supervision as sv
 import torchvision.transforms as T
-from util.box_annotator import BoxAnnotator
+# Use relative import so that utils can be imported as a package module
+# regardless of whether OmniParser is installed as a package or run from the
+# project root.
+from .box_annotator import BoxAnnotator
 
 # ──────────────────────────────
 # Singleton for PaddleOCR


### PR DESCRIPTION
## Summary
- 修正 `OmniParser.util.utils` 對 `BoxAnnotator` 的匯入路徑

## Testing
- `python -m py_compile OmniParser/util/utils.py`
- `python worker_batch.py --debug-dir "dummy" --batch-size 1` *(fails: ModuleNotFoundError: No module named 'paddle')*