### PR TITLE
修正 YOLO 載入函式

### DIFF
--- a/OmniParser/util/utils.py
+++ b/OmniParser/util/utils.py
@@ -95,10 +95,12 @@ def get_caption_model_processor(model_name, model_name_or_path="Salesforce/blip2
     return {'model': model.to(device), 'processor': processor}
 
 
-def get_yolo_model(model_path):
+def get_yolo_model(model_path, device=None):
+    """Load YOLO model with optional device placement."""
     from ultralytics import YOLO
-    # Load the model.
     model = YOLO(model_path)
+    if device:
+        model.to(device)
     return model
 
 


### PR DESCRIPTION
## 摘要
- 讓 `get_yolo_model` 可以接受 `device` 參數並在需要時將模型移到指定裝置

## 測試
- `python -m py_compile OmniParser/util/utils.py`
- `python -m py_compile worker_batch.py worker.py`

此環境在安裝後無法使用網路，因此無法完整執行 `worker_batch.py` 等需額外依賴的指令。