### PR TITLE
Optimize prefetch size

### DIFF
--- a/util/memory.py
+++ b/util/memory.py
@@ -50,3 +50,27 @@ def release_ocr_gpu_cache(ocr_reader):
         except Exception:
             pass
 
+
+# 控制 GPU 快取清理頻率的計數器
+_CACHE_COUNTER = 0
+
+
+def maybe_empty_gpu_cache(interval: int = 10) -> None:
+    """依照指定間隔釋放 GPU 快取，避免過度頻繁造成耗時"""
+    global _CACHE_COUNTER
+    _CACHE_COUNTER += 1
+    if _CACHE_COUNTER < interval:
+        return
+    _CACHE_COUNTER = 0
+    try:
+        if torch and torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except Exception:
+        pass
+    try:
+        if paddle and paddle.is_compiled_with_cuda():
+            paddle.device.cuda.empty_cache()
+    except Exception:
+        pass
+    debug_gpu_memory("maybe_empty_gpu_cache")
+

--- a/util/prefetch.py
+++ b/util/prefetch.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import os
 from pathlib import Path
 from typing import Dict, Iterable, Tuple, Optional
 import hashlib
@@ -12,39 +15,58 @@ from PIL import Image
 class ImagePrefetcher:
     """簡單的影像預讀快取，預設保留 5 張。"""
 
-    def __init__(self, size: int = 5) -> None:
+    def __init__(self, size: int = 5, workers: int | None = None) -> None:
         self.size = size
+        self.workers = workers or min(4, os.cpu_count() or 1)
         self._cache: Dict[Path, Tuple[bytes, str]] = {}
         self._order: deque[Path] = deque()
+        self._lock = threading.Lock()
 
     def prefetch(self, paths: Iterable[Path | str]) -> None:
         """將給定路徑的圖片讀入快取，超出大小時會自動淘汰最舊項目"""
+
+        targets: list[Path] = []
         for p in paths:
             path = Path(p)
-            if path in self._cache:
+            if path in self._cache or path in targets:
                 continue
+            targets.append(path)
+
+        def _load(path: Path):
             try:
                 data = path.read_bytes()
                 sha = hashlib.sha256(data).hexdigest()
+                return path, data, sha
             except Exception:
-                continue
-            if len(self._order) >= self.size:
-                old = self._order.popleft()
-                self._cache.pop(old, None)
-            self._cache[path] = (data, sha)
-            self._order.append(path)
+                return None
+
+        with ThreadPoolExecutor(max_workers=self.workers) as exe:
+            for result in exe.map(_load, targets):
+                if result is None:
+                    continue
+                path, data, sha = result
+                with self._lock:
+                    if path in self._cache:
+                        continue
+                    if len(self._order) >= self.size:
+                        old = self._order.popleft()
+                        self._cache.pop(old, None)
+                    self._cache[path] = (data, sha)
+                    self._order.append(path)
 
     def pop_image(self, p: Path | str) -> Optional[Image.Image]:
         """取得並移除快取中的圖片，如不存在則回傳 None"""
         path = Path(p)
-        entry = self._cache.pop(path, None)
-        if entry is None:
-            return None
-        self._order.remove(path)
+        with self._lock:
+            entry = self._cache.pop(path, None)
+            if entry is None:
+                return None
+            self._order.remove(path)
         data, _sha = entry
         return Image.open(io.BytesIO(data)).convert("RGB")
 
     def get_sha(self, p: Path | str) -> Optional[str]:
         path = Path(p)
-        entry = self._cache.get(path)
-        return entry[1] if entry else None
+        with self._lock:
+            entry = self._cache.get(path)
+            return entry[1] if entry else None

--- a/worker.py
+++ b/worker.py
@@ -152,8 +152,8 @@ from sqlalchemy import create_engine, text  # noqa: E402
 logging.basicConfig(level=getattr(logging, LOG_LEVEL), format="%(asctime)s [%(levelname)s] %(message)s")
 engine = create_engine(DB_URL, pool_size=THREADS*2, max_overflow=0)
 
-# 影像預讀快取，容量為兩個分批大小
-PREFETCHER = ImagePrefetcher(size=BATCH_SIZE * 2)
+# 影像預讀快取，容量與分批大小一致
+PREFETCHER = ImagePrefetcher(size=BATCH_SIZE)
 
 # ───────────────────────────
 # Helper functions
@@ -260,9 +260,9 @@ def handle_row(row):
 def worker_loop():
     task_queue: list[dict] = []
     while True:
-        # 確保快取中維持兩個分批的圖片
-        if len(task_queue) < BATCH_SIZE * 2:
-            new_tasks = claim_tasks(BATCH_SIZE * 2 - len(task_queue))
+        # 依分批大小預先讀取圖片
+        if len(task_queue) < BATCH_SIZE:
+            new_tasks = claim_tasks(BATCH_SIZE - len(task_queue))
             if new_tasks:
                 PREFETCHER.prefetch(db_to_local(r["img_path"]) for r in new_tasks)
                 task_queue.extend(new_tasks)


### PR DESCRIPTION
## Summary
- keep image prefetch cache size equal to batch size
- adjust worker loops to fetch only one batch ahead
- document CLI control of batch size

## Testing
- `python -m py_compile util/prefetch.py util/memory.py worker_batch.py worker.py`
