### PR TITLE
修復OCR BBox為None時的處理邏輯

### DIFF
--- a/OmniParser/util/utils.py
+++ b/OmniParser/util/utils.py
@@ -455,12 +455,22 @@ def get_som_labeled_img(image_source: Union[str, Image.Image], model=None, BOX_T
     # annotate the image with labels
     if ocr_bbox:
         ocr_bbox = torch.tensor(ocr_bbox) / torch.Tensor([w, h, w, h])
-        ocr_bbox=ocr_bbox.tolist()
+        ocr_bbox = ocr_bbox.tolist()
     else:
         print('no ocr bbox!!!')
-        ocr_bbox = None
+        ocr_bbox = []
 
-    ocr_bbox_elem = [{'type': 'text', 'bbox':box, 'interactivity':False, 'content':txt, 'source': 'box_ocr_content_ocr'} for box, txt in zip(ocr_bbox, ocr_text) if int_box_area(box, w, h) > 0] 
+    ocr_bbox_elem = [
+        {
+            'type': 'text',
+            'bbox': box,
+            'interactivity': False,
+            'content': txt,
+            'source': 'box_ocr_content_ocr'
+        }
+        for box, txt in zip(ocr_bbox, ocr_text)
+        if int_box_area(box, w, h) > 0
+    ]
     xyxy_elem = [{'type': 'icon', 'bbox':box, 'interactivity':True, 'content':None} for box in xyxy.tolist() if int_box_area(box, w, h) > 0]
     filtered_boxes = remove_overlap_new(boxes=xyxy_elem, iou_threshold=iou_threshold, ocr_bbox=ocr_bbox_elem)
     


### PR DESCRIPTION
## Summary
- 修正 `get_som_labeled_img` 在沒有 OCR 結果時會拋出 `TypeError` 的問題

## Testing
- `python -m py_compile OmniParser/util/utils.py`
