### PR TITLE
修正 multiprocessing 啟動錯誤

### DIFF
--- a/util/model_service.py
+++ b/util/model_service.py
@@ -4,8 +4,10 @@ from typing import List, Tuple
 from PIL import Image
 
 # Ensure CUDA works with multiprocessing
-if mp.get_start_method(allow_none=True) != "spawn":
-    mp.set_start_method("spawn", force=True)
+def ensure_spawn_start_method() -> None:
+    """Configure multiprocessing to use the 'spawn' start method."""
+    if mp.get_start_method(allow_none=True) != "spawn":
+        mp.set_start_method("spawn", force=True)
 
 
 class _BaseProcess(mp.Process):

--- a/worker_batch.py
+++ b/worker_batch.py
@@ -30,9 +30,8 @@ import io
 import atexit
 import multiprocessing as mp
 
-# Ensure CUDA works with multiprocessing
-if mp.get_start_method(allow_none=True) != "spawn":
-    mp.set_start_method("spawn", force=True)
+from util.model_service import ensure_spawn_start_method
+
 
 from util.memory import (
     debug_gpu_memory,
@@ -330,6 +329,8 @@ def worker_loop():
 # ───────────────────────────
 def main() -> None:
     global args, DEBUG, DEBUG_IMG, DEBUG_DIR, BATCH_SIZE, PREFETCHER
+
+    ensure_spawn_start_method()
 
     args = _parse_args()
     DEBUG = args.debug or bool(args.debug_dir)


### PR DESCRIPTION
## Summary
- 將 `multiprocessing.set_start_method` 封裝成 `ensure_spawn_start_method`
- 在主程式啟動時呼叫此函式，避免子進程重新設定 start method

## Testing
- `python -m py_compile worker_batch.py util/model_service.py`