### PR TITLE
修正圖片預讀順序

### DIFF
--- a/worker_batch.py
+++ b/worker_batch.py
@@ -410,8 +410,8 @@ def handle_rows(rows) -> List[Tuple[int, str, str, List[str]]]:
             raise FileNotFoundError(local)
 
         assert PREFETCHER is not None
-        _ = PREFETCHER.pop_image(local)
         sha_now = PREFETCHER.get_sha(local)
+        _ = PREFETCHER.pop_image(local)
         if sha_now is None:
             sha_now = sha256_file(local)
         sha_db = row["sha256_img"] or ""


### PR DESCRIPTION
## Notes
- 只在 `claim_tasks()` 中進行圖片預讀
- `handle_rows()` 先取出 SHA 再移除快取，避免因順序錯誤而重新計算

## Summary
- 確保任務被取出時即預讀圖片
- 修正 `handle_rows()` 使用快取的順序