### PR TITLE
update sha256_file to accept bytes

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -52,7 +52,7 @@ def _collect_paths_for_pc(pc_dir: Path, min_date: date) -> list[tuple[str, str]]
             continue
         for img in date_dir.iterdir():
             if img.is_file() and img.suffix.lower() in IMG_SUFFIXES:
-                lst.append((str(img), sha256_file(img)))
+                lst.append((str(img), sha256_file(img.read_bytes())))
     return lst
 
 def scan_to_temp(tmp_file: io.TextIOBase, min_date: date) -> int:

--- a/util/hash_utils.py
+++ b/util/hash_utils.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
 import hashlib
-from pathlib import Path
 
-
-def sha256_file(fp: Path | str) -> str:
-    """回傳檔案內容的 SHA-256 雜湊值"""
-    path = Path(fp)
+def sha256_file(data: bytes) -> str:
+    """回傳影像資料的 SHA-256 雜湊值"""
     h = hashlib.sha256()
-    with path.open("rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            h.update(chunk)
+    h.update(data)
     return h.hexdigest()

--- a/worker_batch.py
+++ b/worker_batch.py
@@ -264,7 +264,7 @@ def save_debug_results(paths: List[Path], texts: List[List[str]]) -> None:
                         json_payload = EXCLUDED.json_payload;
                 """
                 ),
-                dict(p=str(p), s=sha256_file(p), j=json.dumps(txt, ensure_ascii=False)),
+                dict(p=str(p), s=sha256_file(p.read_bytes()), j=json.dumps(txt, ensure_ascii=False)),
             )
 
 # ───────────────────────────
@@ -405,7 +405,7 @@ def handle_rows(rows) -> List[Tuple[int, str, str, List[str]]]:
         sha_now = PREFETCHER.get_sha(local)
         _ = PREFETCHER.pop_image(local)
         if sha_now is None:
-            sha_now = sha256_file(local)
+            sha_now = sha256_file(local.read_bytes())
         sha_db = row["sha256_img"] or ""
         if sha_db and sha_db != sha_now:
             raise ValueError("sha256_img mismatch")


### PR DESCRIPTION
## Summary
- compute file hashes from bytes instead of file paths
- adapt sync scanner to use new helper
- update worker to hash bytes of images

## Testing
- `pytest -q`
- `python -m compileall -q util sync.py worker_batch.py`
